### PR TITLE
Add Android Tagging and Aliasing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,3 +73,4 @@ History
 * 0.3 Added deregister, device token list, other minor improvements
 * 0.4 Added batch push
 * 0.5 Added Android, Blackberry, Rich Push, and scheduled notifications
+* 0.6 Added Android APID Tagging and Aliasing

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 
 setup(
     name="urbanairship",
-    version="0.5",
+    version="0.6",
     author="Adam Lowry",
     author_email="adam@urbanairship.com",
     url="http://urbanairship.com/",

--- a/urbanairship.py
+++ b/urbanairship.py
@@ -123,6 +123,25 @@ class Airship(object):
             raise AirshipFailure(status, response)
         return status == 201
 
+    def update_apid(self, apid=None, alias=None, tags=None):
+        url = APID_URL + apid
+        payload = {}
+        if alias is not None:
+            payload['alias'] = alias
+        if tags is not None:
+            payload['tags'] = tags
+        if payload:
+            body = json.dumps(payload)
+            content_type = 'application/json'
+        else:
+            body = ''
+            content_type = None
+
+        status, response = self._request('PUT', body, url, content_type)
+        if not status in (200, 201):
+            raise AirshipFailure(status, response)
+        return status == 201
+
     def deregister(self, device_token):
         """Mark this device token as inactive"""
         url = DEVICE_TOKEN_URL + device_token


### PR DESCRIPTION
Add the ability to update a given APID with an alias an a set of tags.

For Example...

```
airship.update_apid(
    apid='<Some APID>',
    alias='the device formerly known as APID',
    tags=['tag1','tag2','tag3']
)
```
