### PR TITLE
Ability to specify client request timeout

### DIFF
--- a/urbanairship/core.py
+++ b/urbanairship/core.py
@@ -49,9 +49,14 @@ class AirshipDeviceList(object):
 
 class Airship(object):
 
-    def __init__(self, key, secret):
+    def __init__(self, key, secret, timeout=None):
+        """
+        :param timeout: (optional) Float describing the timeout of 
+                        the request (in seconds).
+        """
         self.key = key
         self.secret = secret
+        self.timeout = timeout
 
         self.session = requests.Session()
         self.session.auth = (key, secret)
@@ -74,7 +79,8 @@ class Airship(object):
             body)
 
         response = self.session.request(
-            method, url, data=body, params=params, headers=headers)
+            method, url, data=body, params=params, headers=headers,
+            timeout=self.timeout)
 
         logger.debug("Received %s response. Headers:\n\t%s\nBody:\n\t%s",
             response.status_code, '\n\t'.join(


### PR DESCRIPTION
Hi,

Added optional parameter for the ua client to time out so that the request to urbanairship server does not hang forever if a problem happens. it is backward compatible change : default timeout to None.

Hope you find this useful

Let me know if that could be merged in master

thanks

-seb