### PR TITLE
Feedback API: Check that "since" is a date and not a datetime

### DIFF
--- a/urbanairship/core.py
+++ b/urbanairship/core.py
@@ -226,6 +226,11 @@ class Airship(object):
             dateutil: http://labix.org/python-dateutil
 
         """
+        # Make sure that the "since" is not a datetime object.
+        try:
+            since = since.date()
+        except AttributeError:
+            pass
         url = common.FEEDBACK_URL
         response = self._request('GET', '', url,
             params={'since': since.isoformat()}, version=1)


### PR DESCRIPTION
UrbanAirship's feedback API documentation clearly states that the "since" object should be of the form 2014-05-15. 

When using the given example ( airship.feedback(datetime.datetime.utcnow() - datetime.timedelta(days=1)) ), the API returns a 400 bad request. The reason is that there's a time portion to the "since" parameter. E.g. 2014-05-15T15:23:45.238315 . 

This fix ensures that even if a datetime object is received, the request to UA's server will only have the date portion of "since". 

The fix was made inside the feedback function instead of to the documentation in order to maintain backwards compatibility.
