### PR TITLE
Surface named_user to ua root

### DIFF
--- a/urbanairship/__init__.py
+++ b/urbanairship/__init__.py
@@ -36,6 +36,7 @@ from .push import (
     interactive,
     scheduled_time,
     local_scheduled_time,
+    named_user,
 )
 
 from .devices import (
@@ -118,6 +119,7 @@ __all__ = [
     PerPushSeries,
     NamedUser,
     NamedUserList,
+    named_user,
 ]
 
 # Silence urllib3 INFO logging by default

--- a/urbanairship/push/__init__.py
+++ b/urbanairship/push/__init__.py
@@ -18,6 +18,7 @@ from .audience import (
     location,
     recent_date,
     absolute_date,
+    named_user,
 )
 
 from .payload import (
@@ -83,5 +84,6 @@ __all__ = [
     actions,
     interactive,
     scheduled_time,
-    local_scheduled_time
+    local_scheduled_time,
+    named_user
 ]


### PR DESCRIPTION
This PR is just an effort in consistency - currently a programmer has explicitly import `named_user` for audience use within a push like so:

```
import urbanairship as ua
from urbanairship.push.audience import named_user
...
push = airship.create_push()
push.audience = named_user("some_unique_identifier")
...
```

With this PR we can interact with `named_user` in the same fashion as we did with `alias` and other audience targets, directly as a member of `urbanairship`:

```
import urbanairship as ua
push = airship.create_push()
push.audience = ua.named_user("some_unique_identifier")
...
```
