### PR TITLE
Allow mocking the PUSH_URL by making logging more robust

### DIFF
--- a/urbanairship/push/core.py
+++ b/urbanairship/push/core.py
@@ -51,7 +51,7 @@ class Push(object):
 
         data = response.json()
         logger.info('Push successful. push_ids: %s',
-                    ', '.join(data['push_ids']))
+                    ', '.join(data.get('push_ids', [])))
 
         return PushResponse(response)
 


### PR DESCRIPTION
Currently there is no support for writing unit tests using the library. Since I do not need to send real pushes during unit tests, mocking `urbanairship.common.PUSH_URL` to send notifications to `https://go.urbanairship.com/api/push/validate/` would be sufficient to make sure the payload is alright.

However, the response for `validate` is just `{"ok":true}`, i.e. data does not contain `push_ids`. Therefore `urbanairship.push.core.Push.send` will raise inside the logging statement. This PR makes the logging more robust, so mocking `urbanairship.common.PUSH_URL` with `https://go.urbanairship.com/api/push/validate/` succeeds and can be used for testing.
