### PR TITLE
Fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "2.6"
   - "3.3"
   - "3.4"
-install: pip install -r requirements.txt --use-mirrors
+install: pip install -r requirements.txt
 script:  nosetests -v --with-doctest
 git:
   submodules: false


### PR DESCRIPTION
`pip` no longer supports the `--use-mirrors` flag. See [this PR](https://github.com/pypa/pip/pull/1098) for a discussion.