### PR TITLE
Remove checks for Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
   - "3.5"
   - "3.6"
   - "3.7"


### PR DESCRIPTION
They're failing on Travis, which means you get a little `build:failing` badge on the README.  I see you don't include 3.3 in `setup.cfg`, so I figure this is what you want anyway.

As an aside, you may want to add 3.8 to this file and `setup.cfg`, but that should probably be a separate PR anyway.

### What does this do and why?

Fixes the build badge on the README


### Airship Contribution Agreement

[Link here](https://docs.google.com/forms/d/e/1FAIpQLScErfiz-fXSPpVZ9r8Di2Tr2xDFxt5MgzUel0__9vqUgvko7Q/viewform)

- [x] I've filled out and signed Airship's contribution agreement form