### PR TITLE
Add (request) timeout parameter to Airship

### DIFF
--- a/urbanairship/core.py
+++ b/urbanairship/core.py
@@ -67,10 +67,11 @@ class Urls(object):
 
 class Airship(object):
 
-    def __init__(self, key, secret, location=None):
+    def __init__(self, key, secret, location=None, request_timeout=None):
         self.key = key
         self.secret = secret
         self.location = location
+        self._request_timeout = request_timeout
 
         self.session = requests.Session()
         self.session.auth = (key, secret)
@@ -135,7 +136,7 @@ class Airship(object):
         )
 
         response = self.session.request(
-            method, url, data=body, params=params, headers=headers)
+            method, url, data=body, params=params, headers=headers, timeout=self._request_timeout)
 
         logger.debug(
             'Received %s response. Headers:\n\t%s\nBody:\n\t%s',


### PR DESCRIPTION

### What does this do and why?

This PR includes the a new timeout parameter to the Airship class making it possible to forward this
value to calls of the request library. Default value is None to be compatible with the current codebase without breaking any prior code. 

We are using Airship services for a product we developed for PepsiCo/Gatorade that is going to be launched on March 1st, 2021. Adding the timeout would give us better protection for our API that uses Airship's services.

### Additional notes for reviewers
* We have not invested on test coverage for this feature yet.

### Testing
- [ ] If these changes added new functionality, I tested them against the live API with real auth
- [ ] I wrote tests covering these changes

* I've tested in virtual environments for python versions:

- [ X] 3.8

### Airship Contribution Agreement
[Link here](https://docs.google.com/forms/d/e/1FAIpQLScErfiz-fXSPpVZ9r8Di2Tr2xDFxt5MgzUel0__9vqUgvko7Q/viewform)

- [X ] I've filled out and signed Airship's contribution agreement form

