### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/push.rst
+++ b/docs/push.rst
@@ -315,7 +315,7 @@ notification, you can update or cancel it before it's sent.
 Scheduled Message Listing
 -------------------------
 
-List all pending Scheduled messages on a project, icluding those to Device Local Time and Best Time to Send:
+List all pending Scheduled messages on a project, including those to Device Local Time and Best Time to Send:
 
    .. code-block:: python
 

--- a/urbanairship/devices/devicelist.py
+++ b/urbanairship/devices/devicelist.py
@@ -37,7 +37,7 @@ class ChannelInfo(object):
         channel.
     :ivar commercial_opted_in: The date-time when a user gave explicit permission
         to receive commercial emails.
-    :ivar commcercial_opted_out: The date-time when a user explicitly denied permission
+    :ivar commercial_opted_out: The date-time when a user explicitly denied permission
         to receive commercial emails.
     :ivar transactional_opted_in: The date-time when a user gave explicit permission to
         receive transactional emails. Users do not need to opt-in to receive

--- a/urbanairship/devices/sms.py
+++ b/urbanairship/devices/sms.py
@@ -14,7 +14,7 @@ class Sms(object):
 
     :param airship: Required. An urbanairship.Airship object instantiated with
         master authentication.
-    :param sender: Required. The a number that recipients will recieve SMS
+    :param sender: Required. The a number that recipients will receive SMS
         notifications from. This must match your Urban Airship configuration.
     :param msisdn: Required. The mobile phone number you want to register as
         an SMS channel (or send a request to opt-in).

--- a/urbanairship/experiments/experiment.py
+++ b/urbanairship/experiments/experiment.py
@@ -19,7 +19,7 @@ class Experiment(object):
         :keyword device_types: An array containing one or more strings identifying
             targeted platforms. Accepted platforms are ios, android, amazon, wns, web,
             sms, email, and open::<open_platform_name>
-        :keywors variants: [required] The variants for the experiment. An experiment
+        :keyword variants: [required] The variants for the experiment. An experiment
             must have at least 1 variant and no more than 26.
         :keyword name: [optional] A name for the experiment
         :keyword description: [optional] A description of the experiment

--- a/urbanairship/push/payload.py
+++ b/urbanairship/push/payload.py
@@ -667,7 +667,7 @@ def open_platform(
         ``url``.
     :keyword template_alert: For use with CreateAndSendPush. A string with
         inline template substitution fields. The name of these must match
-        subsititutions on the OpenChannel objects used with CreateAndSendPush.
+        substitutions on the OpenChannel objects used with CreateAndSendPush.
 
     >>> sms_overrides = open_platform(
     ...    alert='Hello!',


### PR DESCRIPTION
There are small typos in:
- docs/push.rst
- urbanairship/devices/devicelist.py
- urbanairship/devices/sms.py
- urbanairship/experiments/experiment.py
- urbanairship/push/payload.py

Fixes:
- Should read `substitutions` rather than `subsititutions`.
- Should read `receive` rather than `recieve`.
- Should read `keyword` rather than `keywors`.
- Should read `including` rather than `icluding`.
- Should read `commercial` rather than `commcercial`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md