### PR TITLE
Import ABC from collections.abc for Python 3.10 compatibility.

### DIFF
--- a/urbanairship/push/payload.py
+++ b/urbanairship/push/payload.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-import collections
+import collections.abc
 import re
 import warnings
 from typing import List, Dict, Optional, Any, Union
@@ -993,7 +993,7 @@ def campaigns(categories: Union[Dict, List, None] = None) -> Dict[str, Any]:
     """
     payload: Dict[str, Any] = {}
     if categories is not None:
-        if not isinstance(categories, collections.Sequence):
+        if not isinstance(categories, collections.abc.Sequence):
             raise TypeError("Each category must be a string")
         if isinstance(categories, list):
             if not categories or len(categories) > 10:
@@ -1039,13 +1039,13 @@ def actions(
     """
     payload: Dict[str, Any] = {}
     if add_tag is not None:
-        if not (isinstance(add_tag, (collections.Sequence))):
+        if not (isinstance(add_tag, (collections.abc.Sequence))):
             raise TypeError("add_tag must be a string or a list of strings")
         if isinstance(add_tag, list) and not add_tag:
             raise ValueError("add_tag list cannot be empty")
         payload["add_tag"] = add_tag
     if remove_tag is not None:
-        if not (isinstance(remove_tag, (collections.Sequence))):
+        if not (isinstance(remove_tag, (collections.abc.Sequence))):
             raise TypeError("remove_tag must be a string or a list of strings")
         if isinstance(remove_tag, list) and not remove_tag:
             raise ValueError("remove_tag list cannot be empty")


### PR DESCRIPTION
### What does this do and why?

Import ABC from collections.abc for Python 3.10 compatibility. Using `collections` was deprecated and removed in Python 3.10 . This PR is compatible with Python 3.6 and above but incompatible with Python 2.

### Additional notes for reviewers
* If applicable, include any information that provides context for these changes.

### Testing
- [ ] If these changes added new functionality, I tested them against the live API with real auth
- [ ] I wrote tests covering these changes

* Tests pass in the GitHub Actions CI for the following Python versions:

- [ ] 3.6
- [ ] 3.7
- [ ] 3.8
- [ ] 3.9

### Airship Contribution Agreement
[Link here](https://docs.google.com/forms/d/e/1FAIpQLScErfiz-fXSPpVZ9r8Di2Tr2xDFxt5MgzUel0__9vqUgvko7Q/viewform)

- [x] I've filled out and signed Airship's contribution agreement form

### Screenshots
* If applicable
