### PR TITLE
Set enabled=True as default for automation listing

### DIFF
--- a/urbanairship/automation/core.py
+++ b/urbanairship/automation/core.py
@@ -91,13 +91,13 @@ class Automation(object):
         return response
 
     def list_automations(
-        self, limit: Optional[int] = None, enabled: bool = False
+        self, limit: Optional[int] = None, enabled: bool = True
     ) -> Response:
         """List active Automations
 
         :keyword limit: Optional, maximum pipelines to return
-        :keyword enabled: Optional, boolean limiter for results to only enabled
-            Pipelines
+        :keyword enabled: Optional, boolean limits results to enabled or not enabled
+            Pipelines (defaults to True)
         """
         params = {}
         if isinstance(limit, int):


### PR DESCRIPTION
### What does this do and why?
See https://urbanairship.atlassian.net/browse/TOOLSLIBS-2098
Because we were setting enabled = False as the default, automation listings were coming back with no results when a project had only enabled automations and no disabled automations. I think we expected that passing enabled=False to the API would show all (not just enabled), but it actually only includes disabled pipelines. This PR sets enabled=True as the default, because that's what people will usually want and we have a different method for listing the disabled ones anyway.

### Testing
- [ ] If these changes added new functionality, I tested them against the live API with real auth
- [ ] I wrote tests covering these changes

* Tests pass in the GitHub Actions CI for the following Python versions:

- [ ] 3.6
- [ ] 3.7
- [ ] 3.8
- [ ] 3.9

### Screenshots
* If applicable
